### PR TITLE
[WIP] fix json schema validation to support formats

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ INSTALL_REQUIRES = [
     'unicodecsv>=0.14,<2.0',
     'isodate>=0.5.4,<2.0',
     'rfc3986>=0.4,<2.0',
+    'rfc3987==1.3.7',
     'tabulator>=1.0.0a5,<2.0',
 ]
 TESTS_REQUIRE = [

--- a/tableschema/validate.py
+++ b/tableschema/validate.py
@@ -32,7 +32,8 @@ def validate(descriptor, no_fail_fast=False):
     # Fail fast
     if not no_fail_fast:
         jsonschema.validate(
-            descriptor, specs.table_schema, cls=_TableSchemaValidator)
+            descriptor, specs.table_schema, cls=_TableSchemaValidator,
+            format_checker=jsonschema.FormatChecker())
 
     # Multiple errors
     else:


### PR DESCRIPTION
**do not merge, this breaks the library**

currently, the json schema validation doesn't validate formats, this PR fixes that.

However, it causes many schemas to become invalid because uri format doesn't support relative file paths.

see frictionlessdata/specs#480 for more details