### PR TITLE
Issue #176 fix the tiebreaking in case of a draw when inferring the schema

### DIFF
--- a/tableschema/infer.py
+++ b/tableschema/infer.py
@@ -4,7 +4,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import operator
 from . import config
 from . import types
 
@@ -127,6 +126,10 @@ class _TypeResolver(object):
     """Get the best matching type/format from a list of possible ones.
     """
 
+    @staticmethod
+    def _sort_key(item):
+        return (item[1], _TYPE_ORDER.index(item[0][0]))
+
     def get(self, results):
 
         variants = set(results)
@@ -147,7 +150,7 @@ class _TypeResolver(object):
                     counts[result] = 1
 
             # tuple representation of `counts` dict sorted by values
-            sorted_counts = sorted(counts.items(), key=operator.itemgetter(1),
+            sorted_counts = sorted(counts.items(), key=self._sort_key,
                                    reverse=True)
             rv = {
                 'type': sorted_counts[0][0][0],

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -87,3 +87,7 @@ class TestInferSchema(base.BaseTestCase):
             schema = tableschema.infer(headers, values, explicit=True)
 
         self.assertTrue(schema['fields'][0].get('constraints'))
+
+    def test_check_type_boolean_string_tie(self):
+        schema = tableschema.infer(["field"],[["f",],["stringish",]])
+        self.assertEqual(schema["fields"][0]["type"], "string")


### PR DESCRIPTION
- fixes #176

---

_TypeResolver has been updated to pick the lowest priority out pf a set of tied values.
The lowest priority is chosen as this is generally the most generic