### PR TITLE
Adapt to rfc3986 1.1.0 interface

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ INSTALL_REQUIRES = [
     'jsonschema>=2.5,<3.0',
     'unicodecsv>=0.14,<2.0',
     'isodate>=0.5.4,<2.0',
-    'rfc3986>=0.4,<2.0',
+    'rfc3986>=1.1.0,<2.0',
     'tabulator>=1.3,<2.0',
 ]
 TESTS_REQUIRE = [

--- a/tableschema/types/string.py
+++ b/tableschema/types/string.py
@@ -8,8 +8,14 @@ import re
 import six
 import uuid
 import base64
-import rfc3986
+import rfc3986.exceptions
+import rfc3986.validators
+import rfc3986.uri
 from ..config import ERROR
+
+
+_uri_from_string = rfc3986.uri.URIReference.from_string
+_uri_validator = rfc3986.validators.Validator().require_presence_of('scheme')
 
 
 # Module API
@@ -18,7 +24,10 @@ def cast_string(format, value, **options):
     if not isinstance(value, six.string_types):
         return ERROR
     if format == 'uri':
-        if not rfc3986.is_valid_uri(value, require_scheme=True):
+        uri = _uri_from_string(value)
+        try:
+            _uri_validator.validate(uri)
+        except rfc3986.exceptions.ValidationError:
             return ERROR
     elif format == 'email':
         if not re.match(_EMAIL_PATTERN, value):

--- a/tests/types/test_string.py
+++ b/tests/types/test_string.py
@@ -16,6 +16,7 @@ from tableschema.config import ERROR
     ('default', '', ''),
     ('default', 0, ERROR),
     ('uri', 'http://google.com', 'http://google.com'),
+    ('uri', '://no-scheme.test', ERROR),
     ('uri', 'string', ERROR),
     ('uri', '', ERROR),
     ('uri', 0, ERROR),


### PR DESCRIPTION
Perhaps accidentally, the rfc3986 module throws a warning on the is_valid_uri function. Regardless, it makes sense to retain a validator object and reuse it.