### PR TITLE
Fix inferring algorithm, make sure to choose the lowest common denominator

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,11 +210,12 @@ Read the whole table and returns as array of rows. Count of rows could be limite
 - `(exceptions.TableSchemaException)` - raises any error occured in this process
 - `(list[])` - returns array of rows (see `table.iter`)
 
-#### `table.infer(limit=100)`
+#### `table.infer(limit=100, confidence=0.75)`
 
 Infer a schema for the table. It will infer and set Table Schema to `table.schema` based on table data.
 
-- `limit (int)` - limit rows samle size
+- `limit (int)` - limit rows sample size
+- `confidence (float)` - how many casting errors are allowed (as a ratio, between 0 and 1)
 - `(dict)` - returns Table Schema descriptor
 
 #### `table.save(target, storage=None, **options)`
@@ -360,7 +361,7 @@ Cast row based on field types and formats.
 - `row (any[])` - data row as an array of values
 - `(any[])` - returns cast data row
 
-#### `schema.infer(rows, headers=1)`
+#### `schema.infer(rows, headers=1, confidence=0.75)`
 
 Infer and set `schema.descriptor` based on data sample.
 
@@ -368,6 +369,7 @@ Infer and set `schema.descriptor` based on data sample.
 - `headers (int/str[])` - data sample headers (one of):
   - row number containing headers (`rows` should contain headers rows)
   - array of headers (`rows` should NOT contain headers rows)
+- `confidence (float)` - how many casting errors are allowed (as a ratio, between 0 and 1)
 - `{dict}` - returns Table Schema descriptor
 
 #### `schema.commit(strict=None)`
@@ -533,12 +535,13 @@ descriptor = infer('data_to_infer.csv')
 
 The number of rows used by `infer` can be limited with the `limit` argument.
 
-#### `infer(source, headers=1, limit=100, **options)`
+#### `infer(source, headers=1, limit=100, confidence=0.75, **options)`
 
 Infer source schema.
 
 - `source (any)` - source as path, url or inline data
 - `headers (int/str[])` - headers rows number or headers list
+- `confidence (float)` - how many casting errors are allowed (as a ratio, between 0 and 1)
 - `(exceptions.TableSchemaException)` - raises any error occured in the process
 - `(dict)` - returns schema descriptor
 

--- a/tableschema/cli.py
+++ b/tableschema/cli.py
@@ -29,9 +29,10 @@ def info():
 @main.command()
 @click.argument('data')
 @click.option('--row_limit', default=100, type=int)
+@click.option('--confidence', default=0.75, type=float)
 @click.option('--encoding', default='utf-8')
 @click.option('--to_file')
-def infer(data, row_limit, encoding, to_file):
+def infer(data, row_limit, confidence, encoding, to_file):
     """Infer a schema from data.
 
     * data must be a local filepath
@@ -41,7 +42,10 @@ def infer(data, row_limit, encoding, to_file):
     * the first line of data must be headers
     * these constraints are just for the CLI
     """
-    descriptor = tableschema.infer(data, encoding=encoding, limit=row_limit)
+    descriptor = tableschema.infer(data,
+                                   encoding=encoding,
+                                   limit=row_limit,
+                                   confidence=confidence)
     if to_file:
         with io.open(to_file, mode='w+t', encoding='utf-8') as dest:
             dest.write(json.dumps(descriptor, ensure_ascii=False, indent=4))

--- a/tableschema/infer.py
+++ b/tableschema/infer.py
@@ -11,7 +11,7 @@ from .table import Table
 
 # Module API
 
-def infer(source, headers=1, limit=100, **options):
+def infer(source, headers=1, limit=100, confidence=0.75, **options):
     """https://github.com/frictionlessdata/tableschema-py#schema
     """
 
@@ -22,5 +22,5 @@ def infer(source, headers=1, limit=100, **options):
         source, headers = headers, source
 
     table = Table(source, headers=headers, **options)
-    descriptor = table.infer(limit=limit)
+    descriptor = table.infer(limit=limit, confidence=confidence)
     return descriptor

--- a/tableschema/table.py
+++ b/tableschema/table.py
@@ -136,7 +136,7 @@ class Table(object):
                 break
         return result
 
-    def infer(self, limit=100):
+    def infer(self, limit=100, confidence=0.75):
         """https://github.com/frictionlessdata/tableschema-py#schema
         """
         if self.__schema is None or self.__headers is None:
@@ -146,7 +146,9 @@ class Table(object):
                 with self.__stream as stream:
                     if self.__schema is None:
                         self.__schema = Schema()
-                        self.__schema.infer(stream.sample[:limit], headers=stream.headers)
+                        self.__schema.infer(stream.sample[:limit],
+                                            headers=stream.headers,
+                                            confidence=confidence)
                     if self.__headers is None:
                         self.__headers = stream.headers
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -161,14 +161,30 @@ def test_save(tmpdir, apply_defaults):
 
 
 def test_infer():
-    schema = Schema()
-    schema.infer([
+    data = [
       ['id', 'age', 'name'],
       ['1','39','Paul'],
       ['2','23','Jimmy'],
       ['3','36','Jane'],
       ['4','N/A','Judy'],
-    ])
+    ]
+    schema = Schema()
+    schema.infer(data)
+    assert schema.descriptor == {
+        'fields': [
+            {'format': 'default', 'name': 'id', 'type': 'integer'},
+            {'format': 'default', 'name': 'age', 'type': 'integer'},
+            {'format': 'default', 'name': 'name', 'type': 'string'}],
+        'missingValues': ['']}
+    data = [
+      ['id', 'age', 'name'],
+      ['1','39','Paul'],
+      ['2','23','Jimmy'],
+      ['3','36','Jane'],
+      ['4','N/A','Judy'],
+    ]
+    schema = Schema()
+    schema.infer(data, confidence=0.8)
     assert schema.descriptor == {
         'fields': [
             {'format': 'default', 'name': 'id', 'type': 'integer'},

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -172,7 +172,7 @@ def test_infer():
     assert schema.descriptor == {
         'fields': [
             {'format': 'default', 'name': 'id', 'type': 'integer'},
-            {'format': 'default', 'name': 'age', 'type': 'integer'},
+            {'format': 'default', 'name': 'age', 'type': 'string'},
             {'format': 'default', 'name': 'name', 'type': 'string'}],
         'missingValues': ['']}
 


### PR DESCRIPTION
- fixes #210
- fixes #209

---

The infer algorithm has a problem - for each sample value in each column, it tries to find the most specific type it can cast it to. Then it counts which type has the most occurrences.

As can be seen in the attached bug, this method is not correct. 

The PR changes the algorithm so it does not find just one type per value, but all applicable types.
Then the selected type is the one with most occurrences (and amongst those - the most specific type). 