### PR TITLE
Support float for integer casting

### DIFF
--- a/tableschema/types/integer.py
+++ b/tableschema/types/integer.py
@@ -6,21 +6,37 @@ from __future__ import unicode_literals
 
 import re
 import six
+from decimal import Decimal
 from ..config import ERROR
 
 
 # Module API
 
+
 def cast_integer(format, value, **options):
-    if not isinstance(value, six.integer_types):
-        if not isinstance(value, six.string_types):
-            return ERROR
+    if isinstance(value, six.integer_types):
+        pass
+
+    elif isinstance(value, six.string_types):
         if not options.get('bareNumber', _DEFAULT_BARE_NUMBER):
             value = re.sub(r'((^\D*)|(\D*$))', '', value)
+
         try:
             value = int(value)
         except Exception:
             return ERROR
+
+    elif isinstance(value, float):
+        if value.is_integer():
+            value = int(value)
+
+    elif isinstance(value, Decimal):
+        if value % 1 == 0:
+            value = int(value)
+
+    else:
+        return ERROR
+
     return value
 
 

--- a/tests/types/test_integer.py
+++ b/tests/types/test_integer.py
@@ -15,6 +15,7 @@ from tableschema.config import ERROR
     ('default', 1, 1, {}),
     ('default', 1 << 63, 1 << 63, {}),
     ('default', '1', 1, {}),
+    ('default', 1.0, 1, {}),
     ('default', '1$', 1, {'bareNumber': False}),
     ('default', 'ab1$', 1, {'bareNumber': False}),
     ('default', '3.14', ERROR, {}),


### PR DESCRIPTION
Added support for float or decimal types in integer casting. Casting only occurs if the float or decimal is already integer-like, otherwise it returns ERROR. fixes #215 