### PR TITLE
Enables metadata in exceptions, adds some metadata to CastErrors

### DIFF
--- a/tableschema/exceptions.py
+++ b/tableschema/exceptions.py
@@ -11,8 +11,9 @@ class DataPackageException(Exception):
 
     # Public
 
-    def __init__(self, message, errors=[]):
+    def __init__(self, message, errors=[], **metadata):
         self.__errors = errors
+        self.__metadata = metadata
         super(Exception, self).__init__(message)
 
     @property
@@ -22,6 +23,10 @@ class DataPackageException(Exception):
     @property
     def errors(self):
         return self.__errors
+
+    @property
+    def metadata(self):
+        return self.__metadata
 
 
 class TableSchemaException(DataPackageException):

--- a/tableschema/field.py
+++ b/tableschema/field.py
@@ -84,7 +84,10 @@ class Field(object):
                 raise exceptions.CastError((
                     'Field "{field.name}" can\'t cast value "{value}" '
                     'for type "{field.type}" with format "{field.format}"'
-                    ).format(field=self, value=value))
+                    ).format(field=self, value=value),
+                    field=dict(name=self.name, type=self.type, format=self.format),
+                    value=value
+                )
 
         # Check value
         if constraints:
@@ -97,7 +100,10 @@ class Field(object):
                     raise exceptions.CastError((
                         'Field "{field.name}" has constraint "{name}" '
                         'which is not satisfied for value "{value}"'
-                        ).format(field=self, name=name, value=value))
+                        ).format(field=self, name=name, value=value),
+                        field=dict(name=self.name, type=self.type, format=self.format),
+                        value=value
+                    )
 
         return cast_value
 

--- a/tableschema/schema.py
+++ b/tableschema/schema.py
@@ -135,7 +135,8 @@ class Schema(object):
         if len(row) != len(self.fields):
             message = 'Row length %s doesn\'t match fields count %s'
             message = message % (len(row), len(self.fields))
-            raise exceptions.CastError(message)
+            raise exceptions.CastError(message,
+                                       row_length=len(row), field_count=len(self.fields))
 
         # Cast row
         for field, value in zip(self.fields, row):

--- a/tableschema/table.py
+++ b/tableschema/table.py
@@ -89,7 +89,9 @@ class Table(object):
                     if self.headers != self.schema.field_names:
                         self.__stream.close()
                         message = 'Table headers don\'t match schema field names'
-                        raise exceptions.CastError(message)
+                        raise exceptions.CastError(message,
+                                                   table_headers=self.headers,
+                                                   schema_field_names=self.schema.field_names)
 
             # Check unique
             if cast:
@@ -100,7 +102,9 @@ class Table(object):
                             self.__stream.close()
                             message = 'Field(s) "%s" duplicates in row "%s"'
                             message = message % (cache['name'], row_number)
-                            raise exceptions.CastError(message)
+                            raise exceptions.CastError(message,
+                                                       duplicate_field=cache['name'],
+                                                       duplicate_row=row_number)
                         cache['data'].add(values)
 
             # Resolve relations

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -58,8 +58,14 @@ def test_cast_value():
 
 
 def test_cast_value_constraint_error():
-    with pytest.raises(exceptions.CastError):
+    try:
         Field(DESCRIPTOR_MAX).cast_value('')
+        assert False
+    except exceptions.CastError as e:
+        assert e.metadata['field']['name'] == DESCRIPTOR_MAX['name']
+        assert e.metadata['field']['format'] == DESCRIPTOR_MAX['format']
+        assert e.metadata['field']['type'] == DESCRIPTOR_MAX['type']
+        assert e.metadata['value'] is None
 
 
 def test_cast_value_constraints_false():


### PR DESCRIPTION
Exceptions in tableschema contain very little info on the reason for the exception (apart from a text message).
For automated processing we want to know more on the source of the error.
I've made a simple change which adds generic metadata to the tableschema exceptions, and added such metadata to `CastError`s sent around the library.

This shouldn't create any compatibility issues with existing code.