### PR TITLE
Allow casting non-strings to booleans as well

### DIFF
--- a/tableschema/types/boolean.py
+++ b/tableschema/types/boolean.py
@@ -12,9 +12,8 @@ from ..config import ERROR
 
 def cast_boolean(format, value, **options):
     if not isinstance(value, bool):
-        if not isinstance(value, six.string_types):
-            return ERROR
-        value = value.strip()
+        if isinstance(value, six.string_types):
+            value = value.strip()
         if value in options.get('trueValues', _TRUE_VALUES):
             value = True
         elif value in options.get('falseValues', _FALSE_VALUES):

--- a/tests/types/test_boolean.py
+++ b/tests/types/test_boolean.py
@@ -32,6 +32,8 @@ from tableschema.config import ERROR
     ('default', 'No', ERROR, {}),
     ('default', 0, ERROR, {}),
     ('default', 1, ERROR, {}),
+    ('default', 0, False, {'falseValues': [0], 'trueValues': [1]}),
+    ('default', 1, True, {'falseValues': [0], 'trueValues': [1]}),
     ('default', '3.14', ERROR, {}),
     ('default', '', ERROR, {}),
     ('default', 'Yes', ERROR, {'trueValues': ['yes']}),


### PR DESCRIPTION
The spec is a little vague w.r.t this, but I see no harm in enabling it.
In fact, when working with Excel files where booleans are represented as ints, this is quite useful.