### PR TITLE
Fix cli validation output

### DIFF
--- a/tableschema/cli.py
+++ b/tableschema/cli.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 
 import os
 import io
+import sys
 import json
 import click
 import tableschema
@@ -58,10 +59,12 @@ def validate(schema):
     """Validate that a supposed schema is in fact a Table Schema."""
     try:
         tableschema.validate(schema)
-        click.echo(False)
+        click.echo("Schema is valid")
+        sys.exit(0)
     except tableschema.exceptions.ValidationError as exception:
-        click.echo(True)
+        click.echo("Schema is not valid")
         click.echo(exception.errors)
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,6 +49,15 @@ def test_infer_schema_greek():
     assert schema_model.get_field('age').type == 'integer'
     assert schema_model.get_field('name').type == 'string'
 
+def test_validate_schema():
+    runner = CliRunner()
+    result = runner.invoke(cli.validate, ['data/schema_valid_simple.json'])
+    assert result.output.splitlines()[0] == 'Schema is valid'
+    assert result.exit_code == 0
+    result = runner.invoke(cli.validate, ['data/schema_invalid_pk_no_fields.json'])
+    assert result.output.splitlines()[0] == 'Schema is not valid'
+    assert result.exit_code == 1
+
 
 @pytest.mark.skip
 def test_infer_schema_greek_no_encoding_defined():


### PR DESCRIPTION
The cli schema validation had its output flipped, e.g.:

```bash
$ tableschema validate data/schema_valid_simple.json
```

returned False

and 

```bash
$ tableschema validate data/schema_invalid_pk_no_fields.json
```

returned True

This PR corrects the output and adds a test.