### PR TITLE
Add guesser_cls and resolver_cls params to `infer.infer`

### DIFF
--- a/tableschema/infer.py
+++ b/tableschema/infer.py
@@ -14,6 +14,7 @@ from .table import Table
 
 def infer(source, headers=1, limit=100, confidence=0.75,
           missing_values=config.DEFAULT_MISSING_VALUES,
+          guesser_cls=None, resolver_cls=None,
           **options):
     """Infer source schema.
 
@@ -22,6 +23,10 @@ def infer(source, headers=1, limit=100, confidence=0.75,
         headers (int/str[]): headers rows number or headers list
         confidence (float): how many casting errors are allowed (as a ratio, between 0 and 1)
         missing_values (str[]): list of missing values (by default `['']`)
+        guesser_cls (class): you can implement inferring strategies by
+            providing type-guessing and type-resolving classes [experimental]
+        resolver_cls (class): you can implement inferring strategies by
+            providing type-guessing and type-resolving classes [experimental]
 
     # Raises
         TableSchemaException: raises any error that occurs during the process
@@ -39,5 +44,6 @@ def infer(source, headers=1, limit=100, confidence=0.75,
 
     table = Table(source, headers=headers, **options)
     descriptor = table.infer(limit=limit, confidence=confidence,
-        missing_values=missing_values)
+        missing_values=missing_values, guesser_cls=guesser_cls,
+        resolver_cls=resolver_cls)
     return descriptor

--- a/tableschema/table.py
+++ b/tableschema/table.py
@@ -357,7 +357,8 @@ class Table(object):
         return result
 
     def infer(self, limit=100, confidence=0.75,
-              missing_values=config.DEFAULT_MISSING_VALUES):
+              missing_values=config.DEFAULT_MISSING_VALUES,
+              guesser_cls=None, resolver_cls=None):
         """Infer a schema for the table.
 
         It will infer and set Table Schema to `table.schema` based on table data.
@@ -366,6 +367,10 @@ class Table(object):
             limit (int): limit rows sample size
             confidence (float): how many casting errors are allowed (as a ratio, between 0 and 1)
             missing_values (str[]): list of missing values (by default `['']`)
+            guesser_cls (class): you can implement inferring strategies by
+                 providing type-guessing and type-resolving classes [experimental]
+            resolver_cls (class): you can implement inferring strategies by
+                 providing type-guessing and type-resolving classes [experimental]
 
         # Returns
             dict: Table Schema descriptor
@@ -380,7 +385,9 @@ class Table(object):
                         self.__schema = Schema({'missingValues': missing_values})
                         self.__schema.infer(stream.sample[:limit],
                                             headers=stream.headers,
-                                            confidence=confidence)
+                                            confidence=confidence,
+                                            guesser_cls=guesser_cls,
+                                            resolver_cls=resolver_cls)
                     if self.__headers is None:
                         self.__headers = stream.headers
 


### PR DESCRIPTION
# Overview

I just added `guesser_cls` and `resolver_cls` params to `infer.infer` and `table.infer`. I think it was missed, because I tried to use `infer.infer` with my own guesser and I failed. 

To be honestly, I'm not sure that `guesser` and `resolver` should be passed as a class. Because after all they are instantiated with no params. Maybe they should be passed as a callable. Or it should be possible to pass something (like `missing_values`) them. But that’s another story, I guess. 

---

Please preserve this line to notify @roll (lead of this repository)
