### PR TITLE
Handle the case when infer gets a list of none headers

### DIFF
--- a/tableschema/schema.py
+++ b/tableschema/schema.py
@@ -335,8 +335,8 @@ class Schema(object):
         resolver = (resolver_cls or _TypeResolver)()
         descriptor = {'fields': [], 'missingValues': missing_values}
         type_matches = {}
-        for header in headers:
-            descriptor['fields'].append({'name': header})
+        for number, header in enumerate(headers, start=1):
+            descriptor['fields'].append({'name': header or 'field%s' % number})
         for index, row in enumerate(rows):
             # Normalize rows with invalid dimensions for sanity
             row_length = len(row)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -439,3 +439,9 @@ def test_schema_not_supported_type_issue_goodatbles_304():
     schema = Schema({'fields': [ {'name': 'name'}, {'name': 'age', 'type': 'bad'} ]})
     assert schema.valid is False
     assert schema.fields[1] is False
+
+
+def test_schema_infer_with_non_headers_issues_goodtables_258():
+    schema = Schema()
+    schema.infer([[1],[2],[3]], headers=[None])
+    assert schema.field_names == ['field1']


### PR DESCRIPTION
- fixes https://github.com/frictionlessdata/goodtables-py/issues/258
- related https://bitbucket.org/openpyxl/openpyxl/issues/1001/empty-columns-are-read-as-none-when
